### PR TITLE
fix: default not in keydown-end

### DIFF
--- a/simaple/simulate/component/entity.py
+++ b/simaple/simulate/component/entity.py
@@ -197,7 +197,7 @@ class LastingStack(Entity):
 class Keydown(Entity):
     interval: float
     interval_counter: float = 0.0
-    time_left: float = 0
+    time_left: float = -1
 
     @property
     def running(self) -> bool:

--- a/test_data/target.py
+++ b/test_data/target.py
@@ -41,21 +41,21 @@ SETTINGS = [
             JobType.archmagetc,
             JobCategory.magician,
         ),
-        6549602605218,
+        6534916107988,
     ),
     (
         (
             JobType.bishop,
             JobCategory.magician,
         ),
-        5387962299243,
+        5324413159316,
     ),
     (
         (
             JobType.mechanic,
             JobCategory.pirate,
         ),
-        5664326354753,
+        5644701182640,
     ),
     (
         (
@@ -76,7 +76,7 @@ SETTINGS = [
                 "weapon_attack_power": 789,
             },
         ),
-        9293806782736,
+        9290299778417,
     ),
     (
         (
@@ -96,7 +96,7 @@ SETTINGS = [
                 "weapon_attack_power": 700,
             },
         ),
-        5382392271117,
+        5354943334938,
     ),
 ]
 


### PR DESCRIPTION
keydown-end의 time_left=0 은 elapse에 의해서만 도달 가능해야 합니다.