### PR TITLE
feat: support rank for template

### DIFF
--- a/docs/modules/about/how_to_use_gear.rst
+++ b/docs/modules/about/how_to_use_gear.rst
@@ -237,8 +237,8 @@ Create gear with GearBlueprint
 
 .. code-block:: python
 
-    from simaple.gear.blueprint.gear_blueprint import PracticalGearBlueprint
-    from simaple.gear.bonus_factory import BonusSpec, BonusType
+    from simaple.gear.blueprint.gear_blueprint import PracticalGearBlueprint, BonusSpec
+    from simaple.gear.bonus_factory import BonusType
 
     blueprint = PracticalGearBlueprint(
         meta=gear_repository.get_gear_meta(1005568),

--- a/simaple/data/baseline/spec/Epic.yaml
+++ b/simaple/data/baseline/spec/Epic.yaml
@@ -18,11 +18,11 @@ spec_hint:
 anchors:
   armor: &armor
     bonuses:
-      - grade: 4
+      - rank: 4
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_third_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     spell_trace:
       probability: 70
@@ -37,11 +37,11 @@ anchors:
         - first_att: 10
   acc: &acc
     bonuses: &acc_bonus
-      - grade: 4
+      - rank: 4
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_third_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     scroll:
       name: 악공
@@ -158,9 +158,9 @@ data:
     weapon:
       gear_id: 앱솔랩스 무기
       bonuses:
-        - grade: 6
+        - rank: 2
           bonus_type: first_att
-        - grade: 5
+        - rank: 3
           bonus_type: boss_damage_multiplier
       spell_trace:
         probability: 15

--- a/simaple/data/baseline/spec/EpicUnique.yaml
+++ b/simaple/data/baseline/spec/EpicUnique.yaml
@@ -18,11 +18,11 @@ spec_hint:
 anchors:
   armor: &armor
     bonuses:
-      - grade: 4
+      - rank: 4
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_third_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     spell_trace:
       probability: 30
@@ -37,11 +37,11 @@ anchors:
         - first_att: 10
   acc: &acc
     bonuses: &acc_bonus
-      - grade: 4
+      - rank: 4
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_third_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     scroll:
       name: 악공
@@ -176,9 +176,9 @@ data:
     weapon:
       gear_id: 아케인셰이드 무기
       bonuses:
-        - grade: 6
+        - rank: 2
           bonus_type: first_att
-        - grade: 5
+        - rank: 3
           bonus_type: boss_damage_multiplier
       spell_trace:
         probability: 15

--- a/simaple/data/baseline/spec/Legendary.yaml
+++ b/simaple/data/baseline/spec/Legendary.yaml
@@ -18,11 +18,11 @@ spec_hint:
 anchors:
   armor: &armor
     bonuses:
-      - grade: 6
+      - rank: 2
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat
-      - grade: 6
+      - rank: 2
         bonus_type: all_stat_multiplier
     spell_trace:
       probability: 30
@@ -39,11 +39,11 @@ anchors:
         - first_stat_multiplier: 4
   acc: &acc
     bonuses: &acc_bonus
-      - grade: 6
+      - rank: 2
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat
-      - grade: 6
+      - rank: 2
         bonus_type: all_stat_multiplier
     scroll:
       name: 악공
@@ -143,9 +143,9 @@ data:
       <<: *acc
       star: 20
       bonuses:
-        - grade: 4
+        - rank: 4
           bonus_type: first_stat
-        - grade: 3
+        - rank: 5
           bonus_type: all_stat_multiplier
     eye_accessory:
       gear_id: 블랙빈 마크
@@ -191,9 +191,9 @@ data:
       <<: *acc
       star: 20
       bonuses:
-        - grade: 4
+        - rank: 4
           bonus_type: first_stat
-        - grade: 3
+        - rank: 5
           bonus_type: all_stat_multiplier  
     pocket:
       gear_id: 핑크빛 성배
@@ -205,9 +205,9 @@ data:
     weapon:
       gear_id: 아케인셰이드 무기
       bonuses:
-        - grade: 6
+        - rank: 2
           bonus_type: first_att
-        - grade: 5
+        - rank: 3
           bonus_type: boss_damage_multiplier
       spell_trace:
         probability: 15

--- a/simaple/data/baseline/spec/Legendary18.yaml
+++ b/simaple/data/baseline/spec/Legendary18.yaml
@@ -18,11 +18,11 @@ spec_hint:
 anchors:
   armor: &armor
     bonuses:
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     spell_trace:
       probability: 30
@@ -38,11 +38,11 @@ anchors:
         - first_stat_multiplier: 4
   acc: &acc
     bonuses: &acc_bonus
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     scroll:
       name: 악공
@@ -184,9 +184,9 @@ data:
     weapon:
       gear_id: 아케인셰이드 무기
       bonuses:
-        - grade: 6
+        - rank: 2
           bonus_type: first_att
-        - grade: 5
+        - rank: 3
           bonus_type: boss_damage_multiplier
       spell_trace:
         probability: 15

--- a/simaple/data/baseline/spec/LegendaryHalf.yaml
+++ b/simaple/data/baseline/spec/LegendaryHalf.yaml
@@ -18,11 +18,11 @@ spec_hint:
 anchors:
   armor: &armor
     bonuses:
-      - grade: 6
+      - rank: 2
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat
-      - grade: 6
+      - rank: 2
         bonus_type: all_stat_multiplier
     spell_trace:
       probability: 30
@@ -39,11 +39,11 @@ anchors:
         - first_stat_multiplier: 4
   acc: &acc
     bonuses: &acc_bonus
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     scroll:
       name: 악공
@@ -186,9 +186,9 @@ data:
     weapon:
       gear_id: 아케인셰이드 무기
       bonuses:
-        - grade: 6
+        - rank: 2
           bonus_type: first_att
-        - grade: 5
+        - rank: 3
           bonus_type: boss_damage_multiplier
       spell_trace:
         probability: 15

--- a/simaple/data/baseline/spec/Unique.yaml
+++ b/simaple/data/baseline/spec/Unique.yaml
@@ -18,11 +18,11 @@ spec_hint:
 anchors:
   armor: &armor
     bonuses:
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     spell_trace:
       probability: 30
@@ -38,11 +38,11 @@ anchors:
         - first_stat_multiplier: 4
   acc: &acc
     bonuses: &acc_bonus
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat_second_stat
-      - grade: 5
+      - rank: 3
         bonus_type: first_stat
-      - grade: 5
+      - rank: 3
         bonus_type: all_stat_multiplier
     scroll:
       name: 악공
@@ -178,9 +178,9 @@ data:
     weapon:
       gear_id: 아케인셰이드 무기
       bonuses:
-        - grade: 6
+        - rank: 2
           bonus_type: first_att
-        - grade: 5
+        - rank: 3
           bonus_type: boss_damage_multiplier
       spell_trace:
         probability: 15

--- a/simaple/gear/bonus_factory.py
+++ b/simaple/gear/bonus_factory.py
@@ -56,11 +56,6 @@ class BonusType(enum.Enum):
         return maybe_reversed
 
 
-class BonusSpec(BaseModel):
-    bonus_type: BonusType
-    grade: int
-
-
 class BonusFactory:
     def __init__(self):
         self._bonus_prototypes = {

--- a/simaple/gear/bonus_factory.py
+++ b/simaple/gear/bonus_factory.py
@@ -1,7 +1,5 @@
 import enum
 
-from pydantic import BaseModel
-
 from simaple.core.base import AttackType, BaseStatType
 from simaple.gear.improvements.bonus import (
     AllstatBonus,

--- a/tests/gear/test_bonus_spec.py
+++ b/tests/gear/test_bonus_spec.py
@@ -1,0 +1,19 @@
+import pytest
+from pydantic import ValidationError
+
+from simaple.gear.blueprint.gear_blueprint import BonusSpec
+from simaple.gear.bonus_factory import BonusFactory, BonusType
+
+
+def test_bonus_spec_block_grade_and_rank_given_together():
+    with pytest.raises(ValueError):
+        _ = BonusSpec(bonus_type=BonusType.all_stat_multiplier, grade=6, rank=2)
+
+
+@pytest.mark.parametrize("value", [0, 8])
+def test_bonus_spec_prevent_value_out_of_range(value):
+    with pytest.raises(ValidationError):
+        _ = BonusSpec(
+            bonus_type=BonusType.all_stat_multiplier,
+            grade=value,
+        )

--- a/tests/gear/test_bonus_spec.py
+++ b/tests/gear/test_bonus_spec.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from simaple.gear.blueprint.gear_blueprint import BonusSpec
-from simaple.gear.bonus_factory import BonusFactory, BonusType
+from simaple.gear.bonus_factory import BonusType
 
 
 def test_bonus_spec_block_grade_and_rank_given_together():


### PR DESCRIPTION
가독성을 증진시키기 위해, rank field를 지원합니다.
rank는 1~7사이의 값입니다. 보스 장신구가 아닌 경우에 rank 1,2는 사용 불가능하다는 점에 유의하세요.
grade field는 그대로 남아있으나, 사용이 권장되지는 않습니다. 
rank와 grade field 둘 모두를 명시할 수는 없습니다.