### PR TITLE
Feature/lint dsl

### DIFF
--- a/scripts/repl.py
+++ b/scripts/repl.py
@@ -5,7 +5,7 @@ import simaple.simulate.component.skill  # pylint: disable=W0611
 from simaple.container.simulation import SimulationContainer, SimulationSetting
 from simaple.core.job_category import JobCategory
 from simaple.core.jobtype import JobType
-from simaple.simulate.report.base import Report, ReportEventHandler
+from simaple.simulate.report.base import Report, ReportWriteCallback
 
 setting = SimulationSetting(
     tier="Legendary",
@@ -26,7 +26,7 @@ engine = container.operation_engine()
 policy = container.engine_configuration().get_default_policy()
 
 report = Report()
-engine.add_callback(ReportEventHandler(report))
+engine.add_callback(ReportWriteCallback(report))
 
 
 def run():

--- a/scripts/repl.py
+++ b/scripts/repl.py
@@ -31,8 +31,8 @@ engine.add_callback(ReportWriteCallback(report))
 
 def run():
     start = time.time()
-    while engine.get_current_viewer()("clock") < 50_000:
-        engine.exec_policy(policy, early_stop=50_000)
+    while engine.get_current_viewer()("clock") < 180_000:
+        engine.exec_policy(policy, early_stop=180_000)
 
     print(
         f"{engine.get_current_viewer()('clock')} | {container.dpm_calculator().calculate_dpm(report):,} "
@@ -40,7 +40,7 @@ def run():
     end = time.time()
     print(f"elapsed: {end - start}")
 
-    assert 8_264_622_367_162.877 == container.dpm_calculator().calculate_dpm(report)
+    # assert 8_264_622_367_162.877 == container.dpm_calculator().calculate_dpm(report)
 
 
 if __name__ == "__main__":

--- a/scripts/show_dpm.py
+++ b/scripts/show_dpm.py
@@ -25,13 +25,9 @@ def test_actor():
     engine.add_callback(ReportWriteCallback(report))
 
     policy = container.engine_configuration().get_default_policy()
-    import time
 
-    start = time.time()
     while engine.get_current_viewer()("clock") < 180_000:
         engine.exec_policy(policy, early_stop=180_000)
-
-    end = time.time()
 
     print(
         f"{engine.get_current_viewer()('clock')} | {container.dpm_calculator().calculate_dpm(report):,} "

--- a/scripts/show_dpm.py
+++ b/scripts/show_dpm.py
@@ -25,13 +25,22 @@ def test_actor():
     engine.add_callback(ReportWriteCallback(report))
 
     policy = container.engine_configuration().get_default_policy()
+    import time
 
-    while engine.get_current_viewer()("clock") < 50_000:
-        engine.exec_policy(policy, early_stop=50_000)
+    start = time.time()
+    while engine.get_current_viewer()("clock") < 180_000:
+        engine.exec_policy(policy, early_stop=180_000)
+
+    end = time.time()
 
     print(
         f"{engine.get_current_viewer()('clock')} | {container.dpm_calculator().calculate_dpm(report):,} "
     )
+
+    for operation_log in engine.operation_logs():
+        timestamp = operation_log.playlogs[0].clock
+        ops = operation_log.operation
+        print(f"{timestamp:.3f} | {ops.expr}")
 
 
 if __name__ == "__main__":

--- a/scripts/show_dpm.py
+++ b/scripts/show_dpm.py
@@ -2,7 +2,7 @@ import simaple.simulate.component.skill  # pylint: disable=W0611
 from simaple.container.simulation import SimulationContainer, SimulationSetting
 from simaple.core.job_category import JobCategory
 from simaple.core.jobtype import JobType
-from simaple.simulate.report.base import Report, ReportEventHandler
+from simaple.simulate.report.base import Report, ReportWriteCallback
 
 setting = SimulationSetting(
     tier="Legendary",
@@ -22,7 +22,7 @@ def test_actor():
 
     report = Report()
     engine = container.operation_engine()
-    engine.add_callback(ReportEventHandler(report))
+    engine.add_callback(ReportWriteCallback(report))
 
     policy = container.engine_configuration().get_default_policy()
 

--- a/simaple/simulate/base.py
+++ b/simaple/simulate/base.py
@@ -286,10 +286,10 @@ class ViewSet:
         return _viewer
 
 
-class EventHandler:
+class PostActionCallback:
     """
-    EventHandler receives "Event" and create "Action" (maybe multiple).
-    Eventhandler receives full context; to provide meaningful decision.
+    PostActionCallback receives "Event" and do any post-action operations.
+    PostActionCallback receives viewer; this ensure callback can read every state, but cannot modify.
     """
 
     def __call__(

--- a/simaple/simulate/base.py
+++ b/simaple/simulate/base.py
@@ -277,9 +277,10 @@ class ViewSet:
             view for view_name, view in self._views.items() if regex.match(view_name)
         ]
 
-    def get_viewer(self, ckpt: Checkpoint) -> ViewerType:
-        store = ckpt.restore()
+    def get_viewer_from_ckpt(self, ckpt: Checkpoint) -> ViewerType:
+        return self.get_viewer(ckpt.restore())
 
+    def get_viewer(self, store: Store) -> ViewerType:
         def _viewer(view_name: str) -> Any:
             return self.show(view_name, store)
 

--- a/simaple/simulate/engine.py
+++ b/simaple/simulate/engine.py
@@ -7,7 +7,7 @@ from simaple.simulate.base import (
     Checkpoint,
     Event,
     EventCallback,
-    EventHandler,
+    PostActionCallback,
     RouterDispatcher,
     ViewerType,
     ViewSet,
@@ -28,7 +28,7 @@ from simaple.simulate.reserved_names import Tag
 
 class SimulationEngine(metaclass=ABCMeta):
     @abstractmethod
-    def add_callback(self, handler: EventHandler) -> None:
+    def add_callback(self, callback: PostActionCallback) -> None:
         """Simulation Engine may ensure that given engine triggers registered callbacks."""
 
 
@@ -40,10 +40,10 @@ class MonotonicEngine(SimulationEngine):
         self._store = store
         self._viewset = viewset
         self._previous_callbacks: list[EventCallback] = []
-        self._callbacks: list[EventHandler] = []
+        self._callbacks: list[PostActionCallback] = []
 
-    def add_callback(self, handler: EventHandler) -> None:
-        self._callbacks.append(handler)
+    def add_callback(self, callback: PostActionCallback) -> None:
+        self._callbacks.append(callback)
 
     def get_viewer(self) -> ViewerType:
         return self._show
@@ -86,7 +86,7 @@ class OperationEngine(SimulationEngine):
 
         self._history = SimulationHistory(store)
         self._parser = OperandDSLParser()
-        self._callbacks: list[EventHandler] = []
+        self._callbacks: list[PostActionCallback] = []
 
     def inspect(self, log: OperationLog) -> list[tuple[PlayLog, ViewerType]]:
         return [
@@ -94,8 +94,8 @@ class OperationEngine(SimulationEngine):
             for playlog in log.playlogs
         ]
 
-    def add_callback(self, handler: EventHandler) -> None:
-        self._callbacks.append(handler)
+    def add_callback(self, callback: PostActionCallback) -> None:
+        self._callbacks.append(callback)
 
     def save_history(self) -> dict[str, Any]:
         return self._history.save()

--- a/simaple/simulate/lint/rules.py
+++ b/simaple/simulate/lint/rules.py
@@ -1,0 +1,5 @@
+from simaple.simulate.base import PostActionCallback
+
+
+class Rule:
+    ...

--- a/simaple/simulate/lint/rules.py
+++ b/simaple/simulate/lint/rules.py
@@ -1,5 +1,0 @@
-from simaple.simulate.base import PostActionCallback
-
-
-class Rule:
-    ...

--- a/simaple/simulate/policy/base.py
+++ b/simaple/simulate/policy/base.py
@@ -180,6 +180,7 @@ class SimulationHistory:
     def discard_after(self, idx: int) -> None:
         """Discard logs after idx."""
         self._logs = self._logs[: idx + 1]
+        self._cached_store = None
 
     def get(self, idx: int) -> OperationLog:
         return self._logs[idx]

--- a/simaple/simulate/policy/base.py
+++ b/simaple/simulate/policy/base.py
@@ -1,6 +1,5 @@
 import functools
 import hashlib
-import json
 from typing import Any, Callable, Generator, Optional, cast
 
 from pydantic import BaseModel, PrivateAttr
@@ -142,7 +141,8 @@ class OperationLog(BaseModel):
 
     def _fast_dumped_string(self) -> str:
         return self.operation.model_dump_json() + "|".join(
-            playlog.model_dump_json(exclude="checkpoint") for playlog in self.playlogs
+            playlog.model_dump_json(exclude=set(["checkpoint"]))
+            for playlog in self.playlogs
         )
 
     def last(self) -> PlayLog:
@@ -175,7 +175,7 @@ class SimulationHistory:
             assert logs is not None
             self._logs = logs
 
-        self._cached_store = None
+        self._cached_store: Optional[AddressedStore] = None
 
     def discard_after(self, idx: int) -> None:
         """Discard logs after idx."""

--- a/simaple/simulate/report/base.py
+++ b/simaple/simulate/report/base.py
@@ -1,7 +1,7 @@
 import pydantic
 
 from simaple.core.base import Stat
-from simaple.simulate.base import Event, EventHandler, ViewerType
+from simaple.simulate.base import Event, PostActionCallback, ViewerType
 from simaple.simulate.reserved_names import Tag
 
 
@@ -48,7 +48,7 @@ class Report(pydantic.BaseModel):
         return self.logs[-1].clock
 
 
-class ReportEventHandler(EventHandler):
+class ReportWriteCallback(PostActionCallback):
     def __init__(self, report: Report):
         self.report = report
 
@@ -61,7 +61,7 @@ class ReportEventHandler(EventHandler):
             self.report.add(current_clock, event, current_buff_state)
 
 
-class LogEventHandler(EventHandler):
+class LoggerCallback(PostActionCallback):
     def __init__(self, report: Report):
         self.report = report
 

--- a/simaple/simulate/util.py
+++ b/simaple/simulate/util.py
@@ -1,10 +1,15 @@
 from loguru import logger
 
-from simaple.simulate.base import Event, EventHandler, ViewerType, message_signature
+from simaple.simulate.base import (
+    Event,
+    PostActionCallback,
+    ViewerType,
+    message_signature,
+)
 from simaple.simulate.reserved_names import Tag
 
 
-class EventDisplayHandler(EventHandler):
+class EventDisplayCallback(PostActionCallback):
     def __call__(self, event: Event, viewer: ViewerType, __: list[Event]) -> None:
         if event["tag"] == Tag.ELAPSED:  # Elapsed log is too verbose
             return

--- a/test_data/test_container_runtime.py
+++ b/test_data/test_container_runtime.py
@@ -2,7 +2,7 @@ import pytest
 
 import simaple.simulate.component.skill  # pylint: disable=W0611
 from simaple.container.simulation import SimulationContainer
-from simaple.simulate.report.base import Report, ReportEventHandler
+from simaple.simulate.report.base import Report, ReportWriteCallback
 from test_data.target import get_test_settings
 
 
@@ -17,7 +17,7 @@ def test_actor(setting, jobtype, expected):
 
     engine = container.operation_engine()
     report = Report()
-    engine.add_callback(ReportEventHandler(report))
+    engine.add_callback(ReportWriteCallback(report))
 
     policy = container.engine_configuration().get_default_policy()
 

--- a/tests/simulate/policy/test_dsl_runtime.py
+++ b/tests/simulate/policy/test_dsl_runtime.py
@@ -6,7 +6,7 @@ import simaple.simulate.component.skill  # pylint: disable=W0611
 from simaple.container.simulation import SimulationContainer, SimulationSetting
 from simaple.core.job_category import JobCategory
 from simaple.core.jobtype import JobType
-from simaple.simulate.report.base import Report, ReportEventHandler
+from simaple.simulate.report.base import Report, ReportWriteCallback
 
 
 @pytest.fixture(name="dsl_list")
@@ -41,7 +41,7 @@ def test_dsl(dsl_list: list[str], dsl_test_setting: SimulationSetting) -> None:
     report = Report()
 
     engine = container.operation_engine()
-    engine.add_callback(ReportEventHandler(report))
+    engine.add_callback(ReportWriteCallback(report))
 
     for dsl in dsl_list:
         engine.exec_dsl(dsl)


### PR DESCRIPTION
- rename EventHandler as PostActionCallback, which is better naming
- speed up simulation via caching store / move store back&forth w/o destroy/regenerate (to ensure immutability)

ArchmageFp 180s simulation time: 10.63 -> 2.91 (x3.64 speed up)