### PR TITLE
fix: mechanic hexa mastery

### DIFF
--- a/simaple/data/jobs/resources/mechanic/skill_profile.yaml
+++ b/simaple/data/jobs/resources/mechanic/skill_profile.yaml
@@ -30,6 +30,7 @@ data:
     - 그라운드 제로
   hexa_mastery:
     "매시브 파이어: IRON-B": "매시브 파이어: IRON-B VI"
+    "매시브 파이어: IRON-B (폭발)": "매시브 파이어: IRON-B VI (폭발)"
     "호밍 미사일": "호밍 미사일 VI"
   component_groups:
     - mechanic


### PR DESCRIPTION
메카닉 헥사 마스터리가 매시브 파이어 2차 타격에 적용되지 않는 것을 수정합니다.