### PR TITLE
fix: bomber time additional missile count

### DIFF
--- a/simaple/simulate/component/specific/mechanic.py
+++ b/simaple/simulate/component/specific/mechanic.py
@@ -239,7 +239,7 @@ class HommingMissile(SkillComponent, UsePeriodicDamageTrait, CooldownValidityTra
     def get_homming_missile_hit(self, state: HommingMissileState) -> int:
         hit = int(self.periodic_hit)
         if state.bomber_time.enabled():
-            hit += 5
+            hit += 6
 
         if state.full_barrage_keydown.running:
             hit += 7


### PR DESCRIPTION
봄버 타임으로 증가하는 호밍 미사일 개수가 잘못 기입된 것을 수정합니다.