### PR TITLE
refactor: component import statements to use common instead of skill

### DIFF
--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 import fire
 
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 from simaple.container.memoizer import PersistentStorageMemoizer
 from simaple.container.plan_metadata import PlanMetadata
 from simaple.container.simulation import SimulationContainer

--- a/simaple/simulate/component/__init__.py
+++ b/simaple/simulate/component/__init__.py
@@ -1,3 +1,0 @@
-# ruff: noqa: F401
-
-import simaple.simulate.component.common

--- a/simaple/simulate/kms.py
+++ b/simaple/simulate/kms.py
@@ -1,4 +1,4 @@
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 import simaple.simulate.component.specific  # noqa: F401
 from simaple.core.base import ActionStat
 from simaple.simulate.base import AddressedStore, ConcreteStore

--- a/test_data/test_container_runtime.py
+++ b/test_data/test_container_runtime.py
@@ -2,7 +2,7 @@ import os
 
 from inline_snapshot import snapshot
 
-import simaple.simulate.component.skill  # pylint: disable=W0611
+import simaple.simulate.component.common  # pylint: disable=W0611
 from simaple.container.environment_provider import BaselineEnvironmentProvider
 from simaple.container.memoizer import PersistentStorageMemoizer
 from simaple.container.simulation import get_damage_calculator, get_operation_engine

--- a/tests/simulate/component/specific/archmagetc/conftest.py
+++ b/tests/simulate/component/specific/archmagetc/conftest.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0621
 import pytest
 
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 import simaple.simulate.component.specific  # noqa: F401
 from simaple.core.base import ActionStat
 from simaple.simulate.component.entity import Periodic

--- a/tests/simulate/component/specific/mechanic/conftest.py
+++ b/tests/simulate/component/specific/mechanic/conftest.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0621
 import pytest
 
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 import simaple.simulate.component.specific  # noqa: F401
 from simaple.core.base import ActionStat
 from simaple.simulate.component.specific.mechanic import RobotMastery

--- a/tests/simulate/component/specific/soulmaster/conftest.py
+++ b/tests/simulate/component/specific/soulmaster/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 import simaple.simulate.component.specific  # noqa: F401
 from simaple.core.base import ActionStat
 from simaple.simulate.global_property import Dynamics

--- a/tests/simulate/conftest.py
+++ b/tests/simulate/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 import simaple.simulate.component.specific  # noqa: F401
 from simaple.spec.repository import DirectorySpecRepository
 

--- a/tests/simulate/policy/test_dsl_runtime.py
+++ b/tests/simulate/policy/test_dsl_runtime.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from inline_snapshot import snapshot
 
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 from simaple.container.environment_provider import BaselineEnvironmentProvider
 from simaple.container.memoizer import PersistentStorageMemoizer
 from simaple.container.simulation import get_damage_calculator, get_operation_engine

--- a/tests/simulate/report/archmagefb/conftest.py
+++ b/tests/simulate/report/archmagefb/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 import simaple.simulate.component.specific  # noqa: F401
 from simaple.core import ActionStat, Stat
 from simaple.data.jobs.builtin import build_skills

--- a/tests/simulate/report/archmagefb/test_overview.py
+++ b/tests/simulate/report/archmagefb/test_overview.py
@@ -1,4 +1,4 @@
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 from simaple.core.base import Stat
 from simaple.simulate.base import Action, SimulationRuntime, message_signature
 from simaple.simulate.reserved_names import Tag

--- a/tests/simulate/test_engine.py
+++ b/tests/simulate/test_engine.py
@@ -1,4 +1,4 @@
-import simaple.simulate.component.skill  # noqa: F401
+import simaple.simulate.component.common  # noqa: F401
 from simaple.container.environment_provider import BaselineEnvironmentProvider
 from simaple.container.memoizer import PersistentStorageMemoizer
 from simaple.container.simulation import get_operation_engine
@@ -47,7 +47,7 @@ ELAPSE 78000
 
 CAST "메이플월드 여신의 축복"
 
-CAST "포이즌 리전" 
+CAST "포이즌 리전"
 CAST "플레임 헤이즈 VI"
 
 CAST "에픽 어드벤쳐"
@@ -61,7 +61,7 @@ CAST "도트 퍼니셔"
 CAST "포이즌 체인"
 CAST "미스트 이럽션 VI"
 CAST "플레임 헤이즈 VI"
-CAST "크레스트 오브 더 솔라" 
+CAST "크레스트 오브 더 솔라"
 CAST "플레임 스윕 VI"
 CAST "플레임 스윕 VI"
 !debug "seq(viewer('validity')).filter(available).filter(has_cooldown).to_list()"


### PR DESCRIPTION
컴포넌트 로더를 위한 import에 동작을 유추하기 어려운 .skill 대신 .common을 로드하도록 변경합니다.