### PR TITLE
feat: components can have periodic_initial_delay

### DIFF
--- a/simaple/data/jobs/resources/archmagefb/components.yaml
+++ b/simaple/data/jobs/resources/archmagefb/components.yaml
@@ -282,6 +282,7 @@ data:
   cooldown_duration: 0
   hit: 0
 
+  periodic_initial_delay: 1_890 # TODO: check summon.summoned / summon.summoned(810?) + summon.attack1.attackAfter(1080)
   periodic_interval: 3_030
   periodic_damage: "{{ 90 + skill_level * 2 }}"
   periodic_hit: 3

--- a/simaple/data/jobs/resources/components/common_v.yaml
+++ b/simaple/data/jobs/resources/components/common_v.yaml
@@ -82,6 +82,7 @@ data:
 
   cooldown_duration: 250_000
 
+  periodic_initial_delay: 2160 # summon.summoned
   periodic_interval: 2100
   periodic_damage: "{{ 275 + 11 * skill_level }}"
   periodic_hit: 6

--- a/simaple/data/jobs/resources/components/cygnus.yaml
+++ b/simaple/data/jobs/resources/components/cygnus.yaml
@@ -14,6 +14,7 @@ data:
   cooldown_duration: 30_000
   delay: 600
 
+  periodic_initial_delay: 120 # TODO: 위치에 따라 다름, 적절한 값 설정해야 함
   periodic_interval: 120
   periodic_damage: "{{ 450 + 18 * skill_level }}"
   periodic_hit: 1

--- a/simaple/data/jobs/resources/components/resistance.yaml
+++ b/simaple/data/jobs/resources/components/resistance.yaml
@@ -33,7 +33,8 @@ data:
   hit: 0
   cooldown_duration: 25_000
 
-  periodic_interval: 1_000
+  periodic_initial_delay: 1_770 # 1350(summon.summoned) + 420(summon.attack1.attackAfter)
+  periodic_interval: 900
   periodic_damage: "{{ 215 + skill_level * 8 }}"
   periodic_hit: 9
   lasting_duration: 10_000

--- a/simaple/data/jobs/resources/mechanic/components.yaml
+++ b/simaple/data/jobs/resources/mechanic/components.yaml
@@ -109,6 +109,7 @@ data:
   hit: 0
   cooldown_duration: 0
 
+  periodic_initial_delay: 1410 # summon.summoned 딜레이 합
   periodic_interval: 1_000
   periodic_damage: 385 # Need to apply passive skill level only
   periodic_hit: 1
@@ -136,6 +137,7 @@ data:
   hit: 0
   cooldown_duration: 0
 
+  periodic_initial_delay: 1860 # summon.summoned 딜레이 합
   periodic_interval: 990
   periodic_damage: 200
   periodic_hit: 1
@@ -162,6 +164,7 @@ data:
   hit: 0
   cooldown_duration: 0
 
+  periodic_initial_delay: 2820 # summon.summoned 딜레이 합
   periodic_interval: 3_000
   periodic_damage: "{{ 350 + skill_level * 5 }}"
   periodic_hit: 3
@@ -239,6 +242,7 @@ data:
   delay: 0
   cooldown_duration: 0
 
+  periodic_initial_delay: 540
   periodic_interval: 540
   periodic_damage: 300
   periodic_hit: 9
@@ -284,10 +288,11 @@ data:
   hit: 0
   cooldown_duration: 8_000
 
+  periodic_initial_delay: 690
   periodic_interval: 250
   periodic_damage: 350
   periodic_hit: 2
-  lasting_duration: 4_000
+  lasting_duration: 4_690 # 4000(지속시간) + 690(선딜)
 
   v_improvement: 2
 ---
@@ -308,6 +313,7 @@ data:
   cooldown_duration: 180_000
   delay: 780
 
+  periodic_initial_delay: 1590 # summon.summoned 딜레이 합 (840) + summon.attack2.attackAfter (750)
   periodic_interval: 1530
   lasting_duration: "{{ (75 + 2 * skill_level) * 1000 }}"
 
@@ -473,6 +479,7 @@ data:
   delay: 0
   cooldown_duration: 0
 
+  periodic_initial_delay: 540
   periodic_interval: 540
   periodic_damage: "{{ 400 + 5 * skill_level }}"
   periodic_hit: 12
@@ -504,6 +511,7 @@ data:
   delay: 4_860
   cooldown_duration: 360_000
 
+  periodic_initial_delay: 1_200
   periodic_interval: 1_200
   periodic_damage: "{{ 1440 + skill_level * 48 }}" # 툴팁 상으로는 1448 + skill_level * 48이나, 실제 반영되는 값이 다름
   periodic_hit: 15

--- a/simaple/data/jobs/resources/windbreaker/components.yaml
+++ b/simaple/data/jobs/resources/windbreaker/components.yaml
@@ -277,6 +277,7 @@ data:
 
   cooldown_duration: 20_000
 
+  periodic_initial_delay: 630
   periodic_interval: 150
   periodic_damage:
     - ["{{ 325 + 13 * skill_level }}"]

--- a/simaple/simulate/component/common/hit_limited_periodic_damage.py
+++ b/simaple/simulate/component/common/hit_limited_periodic_damage.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from simaple.simulate.component.base import ReducerState, reducer_method, view_method
 from simaple.simulate.component.entity import Cooldown, Periodic
 from simaple.simulate.component.skill import SkillComponent
@@ -21,6 +23,7 @@ class HitLimitedPeriodicDamageComponent(
     cooldown_duration: float
     delay: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -31,7 +34,11 @@ class HitLimitedPeriodicDamageComponent(
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/common/periodic_damage_configurated_attack_skill.py
+++ b/simaple/simulate/component/common/periodic_damage_configurated_attack_skill.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from simaple.simulate.component.base import ReducerState, reducer_method, view_method
 from simaple.simulate.component.entity import Cooldown, Periodic
 from simaple.simulate.component.skill import SkillComponent
@@ -25,6 +27,7 @@ class PeriodicDamageConfiguratedAttackSkillComponent(
 
     cooldown_duration: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -34,7 +37,11 @@ class PeriodicDamageConfiguratedAttackSkillComponent(
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/common/periodic_damage_configurated_hexa_skill.py
+++ b/simaple/simulate/component/common/periodic_damage_configurated_hexa_skill.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from simaple.simulate.component.base import ReducerState, reducer_method, view_method
 from simaple.simulate.component.entity import Cooldown, Periodic
 from simaple.simulate.component.feature import DamageAndHit
@@ -32,6 +34,7 @@ class PeriodicDamageConfiguratedHexaSkillComponent(
 
     cooldown_duration: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -41,7 +44,11 @@ class PeriodicDamageConfiguratedHexaSkillComponent(
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method
@@ -60,9 +67,7 @@ class PeriodicDamageConfiguratedHexaSkillComponent(
         state.cooldown.set_time_left(
             state.dynamics.stat.calculate_cooldown(self._get_cooldown_duration())
         )
-        state.periodic.set_time_left(
-            self._get_lasting_duration(state), initial_counter=delay
-        )
+        state.periodic.set_time_left(self._get_lasting_duration(state))
 
         return state, [
             self.event_provider.dealt(entry.damage, entry.hit)

--- a/simaple/simulate/component/common/periodic_with_finish_skill.py
+++ b/simaple/simulate/component/common/periodic_with_finish_skill.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from simaple.simulate.component.base import ReducerState, reducer_method, view_method
 from simaple.simulate.component.entity import Cooldown, Periodic
 from simaple.simulate.component.skill import SkillComponent
@@ -24,6 +26,7 @@ class PeriodicWithFinishSkillComponent(
 
     cooldown_duration: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -36,7 +39,11 @@ class PeriodicWithFinishSkillComponent(
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/common/triple_periodic_damage_hexa_skill.py
+++ b/simaple/simulate/component/common/triple_periodic_damage_hexa_skill.py
@@ -47,9 +47,21 @@ class TriplePeriodicDamageHexaComponent(SkillComponent, InvalidatableCooldownTra
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic_01": Periodic(interval=self.periodic_01.interval, time_left=0),
-            "periodic_02": Periodic(interval=self.periodic_02.interval, time_left=0),
-            "periodic_03": Periodic(interval=self.periodic_03.interval, time_left=0),
+            "periodic_01": Periodic(
+                interval=self.periodic_01.interval,
+                initial_counter=self.periodic_01.initial_delay,
+                time_left=0,
+            ),
+            "periodic_02": Periodic(
+                interval=self.periodic_02.interval,
+                initial_counter=self.periodic_02.initial_delay,
+                time_left=0,
+            ),
+            "periodic_03": Periodic(
+                interval=self.periodic_03.interval,
+                initial_counter=self.periodic_03.initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/entity.py
+++ b/simaple/simulate/component/entity.py
@@ -95,7 +95,7 @@ class Cycle(Entity):
 
 class Periodic(Entity):
     interval: float = pydantic.Field(gt=0)
-    initial_counter: Optional[float] = pydantic.Field(gt=0)
+    initial_counter: Optional[float] = pydantic.Field(gt=0, default=None)
 
     interval_counter: float = pydantic.Field(gt=0, default=999_999_999)
     time_left: float = 0.0
@@ -109,7 +109,9 @@ class Periodic(Entity):
         """
 
         self.time_left = time
-        self.interval_counter = self.interval  # interval count = 0 is not allowed. emit event and increase interval counter.
+        self.interval_counter = (
+            self.interval
+        )  # interval count = 0 is not allowed. emit event and increase interval counter.
         self.count = 1
 
         return 1

--- a/simaple/simulate/component/entity.py
+++ b/simaple/simulate/component/entity.py
@@ -94,8 +94,9 @@ class Cycle(Entity):
 
 
 class Periodic(Entity):
-    interval_counter: float = pydantic.Field(gt=0, default=999_999_999)
     interval: float = pydantic.Field(gt=0)
+    initial_counter: Optional[float] = pydantic.Field(gt=0)
+    interval_counter: float = pydantic.Field(gt=0, default=999_999_999)
     time_left: float = 0.0
     count: int = 0
 
@@ -107,9 +108,7 @@ class Periodic(Entity):
         """
 
         self.time_left = time
-        self.interval_counter = (
-            self.interval
-        )  # interval count = 0 is not allowed. emit event and increase interval counter.
+        self.interval_counter = self.interval  # interval count = 0 is not allowed. emit event and increase interval counter.
         self.count = 1
 
         return 1
@@ -125,6 +124,10 @@ class Periodic(Entity):
         """
         if time <= 0:
             raise ValueError("Given time may greater than 0")
+
+        initial_counter = (
+            initial_counter if initial_counter is not None else self.initial_counter
+        )
 
         if initial_counter is not None and initial_counter <= 0:
             raise ValueError(

--- a/simaple/simulate/component/entity.py
+++ b/simaple/simulate/component/entity.py
@@ -125,10 +125,6 @@ class Periodic(Entity):
         if time <= 0:
             raise ValueError("Given time may greater than 0")
 
-        initial_counter = (
-            initial_counter if initial_counter is not None else self.initial_counter
-        )
-
         if initial_counter is not None and initial_counter <= 0:
             raise ValueError(
                 "Initial counter may greater than 0. Maybe you intended `set_time_left_without_delay`?"

--- a/simaple/simulate/component/entity.py
+++ b/simaple/simulate/component/entity.py
@@ -96,6 +96,7 @@ class Cycle(Entity):
 class Periodic(Entity):
     interval: float = pydantic.Field(gt=0)
     initial_counter: Optional[float] = pydantic.Field(gt=0)
+
     interval_counter: float = pydantic.Field(gt=0, default=999_999_999)
     time_left: float = 0.0
     count: int = 0
@@ -113,9 +114,7 @@ class Periodic(Entity):
 
         return 1
 
-    def set_time_left(
-        self, time: float, initial_counter: Optional[float] = None
-    ) -> None:
+    def set_time_left(self, time: float) -> None:
         """
         Set left time, with initial counter value.
         If initial counter not specified, default initial counter is `interval`.
@@ -125,14 +124,14 @@ class Periodic(Entity):
         if time <= 0:
             raise ValueError("Given time may greater than 0")
 
-        if initial_counter is not None and initial_counter <= 0:
+        if self.initial_counter is not None and self.initial_counter <= 0:
             raise ValueError(
                 "Initial counter may greater than 0. Maybe you intended `set_time_left_without_delay`?"
             )
 
         self.time_left = time
         self.interval_counter = (
-            initial_counter if initial_counter is not None else self.interval
+            self.initial_counter if self.initial_counter is not None else self.interval
         )
         self.count = 0
 

--- a/simaple/simulate/component/feature.py
+++ b/simaple/simulate/component/feature.py
@@ -4,6 +4,8 @@ feature.py
 This file contains `common` structs and classes that are used in multiple places.
 """
 
+from typing import Optional
+
 import pydantic
 
 
@@ -25,3 +27,4 @@ class PeriodicFeature(pydantic.BaseModel):
     damage: float
     hit: float
     interval: float
+    initial_delay: Optional[float] = pydantic.Field(default=None)

--- a/simaple/simulate/component/specific/archmagefb.py
+++ b/simaple/simulate/component/specific/archmagefb.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from simaple.core import Stat
 from simaple.simulate.base import Entity
 from simaple.simulate.component.base import (
@@ -183,6 +185,7 @@ class PoisonChainComponent(
     cooldown_duration: float
     delay: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -193,7 +196,11 @@ class PoisonChainComponent(
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
             "stack": Stack(maximum_stack=5),
         }
 
@@ -331,6 +338,7 @@ class IfrittComponent(
 
     cooldown_duration: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -343,7 +351,11 @@ class IfrittComponent(
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/specific/archmagetc.py
+++ b/simaple/simulate/component/specific/archmagetc.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from simaple.core.base import Stat
 from simaple.simulate.base import Entity
 from simaple.simulate.component.base import (
@@ -92,6 +94,7 @@ class JupyterThunder(SkillComponent, UsePeriodicDamageTrait, CooldownValidityTra
     cooldown_duration: float
     delay: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -104,7 +107,11 @@ class JupyterThunder(SkillComponent, UsePeriodicDamageTrait, CooldownValidityTra
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method
@@ -256,7 +263,7 @@ class CurrentField(Entity):
 
     def create_new_current(self):
         periodic = Periodic(
-            interval=self.field_interval,
+            interval=self.field_interval, initial_counter=self.field_interval
         )
         periodic.set_time_left(self.field_duration)
 
@@ -384,6 +391,7 @@ class ThunderBreak(SkillComponent, UsePeriodicDamageTrait, CooldownValidityTrait
     cooldown_duration: float
     delay: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -400,7 +408,11 @@ class ThunderBreak(SkillComponent, UsePeriodicDamageTrait, CooldownValidityTrait
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/specific/bishop.py
+++ b/simaple/simulate/component/specific/bishop.py
@@ -103,6 +103,7 @@ class DivineMinion(
     cooldown_duration: float
     delay: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -116,12 +117,20 @@ class DivineMinion(
             return {
                 "divine_mark": DivineMark(),
                 "cooldown": Cooldown(time_left=0),
-                "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+                "periodic": Periodic(
+                    interval=self.periodic_interval,
+                    initial_counter=self.periodic_initial_delay,
+                    time_left=0,
+                ),
             }
 
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/specific/flora.py
+++ b/simaple/simulate/component/specific/flora.py
@@ -29,6 +29,7 @@ class MagicCurcuitFullDriveComponent(
 
     max_damage_multiplier: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -36,7 +37,11 @@ class MagicCurcuitFullDriveComponent(
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/specific/mechanic.py
+++ b/simaple/simulate/component/specific/mechanic.py
@@ -126,6 +126,7 @@ class RobotSummonSkill(
     cooldown_duration: float
     delay: float
 
+    periodic_initial_delay: float
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -134,7 +135,11 @@ class RobotSummonSkill(
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method
@@ -199,6 +204,7 @@ class HommingMissile(SkillComponent, UsePeriodicDamageTrait, CooldownValidityTra
     cooldown_duration: float
     delay: float
 
+    periodic_initial_delay: float
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -209,7 +215,11 @@ class HommingMissile(SkillComponent, UsePeriodicDamageTrait, CooldownValidityTra
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method
@@ -373,6 +383,7 @@ class MultipleOptionComponent(SkillComponent, CooldownValidityTrait):
     cooldown_duration: float
     delay: float
 
+    periodic_initial_delay: float
     periodic_interval: float
     lasting_duration: float
 
@@ -389,7 +400,11 @@ class MultipleOptionComponent(SkillComponent, CooldownValidityTrait):
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
             "cycle": Cycle(tick=0, period=self.missile_count + self.gatling_count),
         }
 

--- a/simaple/simulate/component/specific/soulmaster.py
+++ b/simaple/simulate/component/specific/soulmaster.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from simaple.core.base import Stat
 from simaple.simulate.base import Entity
 from simaple.simulate.component.base import (
@@ -241,6 +243,7 @@ class CosmicShower(SkillComponent, PeriodicElapseTrait, CooldownValidityTrait):
 
     cooldown_duration: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -251,7 +254,11 @@ class CosmicShower(SkillComponent, PeriodicElapseTrait, CooldownValidityTrait):
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method
@@ -316,6 +323,7 @@ class Cosmos(SkillComponent, PeriodicElapseTrait, CooldownValidityTrait):
 
     cooldown_duration: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: float
     periodic_hit: float
@@ -326,7 +334,11 @@ class Cosmos(SkillComponent, PeriodicElapseTrait, CooldownValidityTrait):
     def get_default_state(self):
         return {
             "cooldown": Cooldown(time_left=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method

--- a/simaple/simulate/component/specific/windbreaker.py
+++ b/simaple/simulate/component/specific/windbreaker.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from simaple.simulate.component.base import ReducerState, reducer_method, view_method
 from simaple.simulate.component.entity import Consumable, Integer, Periodic
 from simaple.simulate.component.skill import SkillComponent
@@ -31,6 +33,7 @@ class HowlingGaleComponent(
 
     cooldown_duration: float
 
+    periodic_initial_delay: Optional[float] = None
     periodic_interval: float
     periodic_damage: list[list[float]]
     periodic_hit: list[list[float]]
@@ -46,7 +49,11 @@ class HowlingGaleComponent(
                 time_left=self.cooldown_duration,
             ),
             "consumed": Integer(stack=0),
-            "periodic": Periodic(interval=self.periodic_interval, time_left=0),
+            "periodic": Periodic(
+                interval=self.periodic_interval,
+                initial_counter=self.periodic_initial_delay,
+                time_left=0,
+            ),
         }
 
     @reducer_method
@@ -80,7 +87,7 @@ class HowlingGaleComponent(
         state.consumed.set_value(consumed)
         state.consumable.stack -= consumed
 
-        state.periodic.set_time_left(self._get_lasting_duration(state), self.delay)
+        state.periodic.set_time_left(self._get_lasting_duration(state))
 
         return state, [
             self.event_provider.delayed(delay),

--- a/test_data/test_container_runtime.py
+++ b/test_data/test_container_runtime.py
@@ -71,7 +71,7 @@ def test_archmagefb_actor():
     dpm = run_actor(environment_provider, JobType.archmagefb)
 
     # then
-    assert int(dpm) == snapshot(16141274170535)
+    assert int(dpm) == snapshot(16156481373708)
 
 
 def test_archmagetc_actor():
@@ -104,7 +104,7 @@ def test_mechanic_actor():
     dpm = run_actor(environment_provider, JobType.mechanic)
 
     # then
-    assert int(dpm) == snapshot(7949745729927)
+    assert int(dpm) == snapshot(7978670689416)
 
 
 def test_adele_actor():

--- a/tests/simulate/component/entity/test_periodic_entity.py
+++ b/tests/simulate/component/entity/test_periodic_entity.py
@@ -13,7 +13,7 @@ from simaple.simulate.component.entity import Periodic
 )
 def test_periodic_iterator(time, interval, expected_count):
     # given
-    periodic = Periodic(interval=interval)
+    periodic = Periodic(interval=interval, initial_counter=None)
     count = periodic.set_time_left_without_delay(1200)
 
     time_to_resolve = time
@@ -41,7 +41,7 @@ def test_periodic_iterator(time, interval, expected_count):
 )
 def test_elapse(time, interval, expected_count):
     # given
-    periodic = Periodic(interval=interval)
+    periodic = Periodic(interval=interval, initial_counter=None)
     count = periodic.set_time_left_without_delay(1200)
 
     # when
@@ -66,8 +66,8 @@ def test_elapse(time, interval, expected_count):
     ],
 )
 def test_periodic_initial_counter(time_left, initial_counter, time, expected):
-    periodic = Periodic(interval=100)
-    periodic.set_time_left(time_left, initial_counter)
+    periodic = Periodic(interval=100, initial_counter=initial_counter)
+    periodic.set_time_left(time_left)
     count = periodic.elapse(time)
 
     assert count == expected

--- a/tests/simulate/component/specific/archmagetc/test_chain_lightning.py
+++ b/tests/simulate/component/specific/archmagetc/test_chain_lightning.py
@@ -31,7 +31,13 @@ def test_current_field_entity_elapse():
     start_current_field.elapse(1000)
 
     assert start_current_field.field_periodics == [
-        Periodic(interval=1000, time_left=3000, count=1, interval_counter=1000)
+        Periodic(
+            interval=1000,
+            initial_counter=1000,
+            time_left=3000,
+            count=1,
+            interval_counter=1000,
+        )
     ]
 
     assert not start_current_field.stack_rng(0.5)
@@ -39,8 +45,20 @@ def test_current_field_entity_elapse():
     start_current_field.elapse(1200)
 
     assert start_current_field.field_periodics == [
-        Periodic(interval_counter=800.0, interval=1000.0, time_left=1800.0, count=2),
-        Periodic(interval_counter=800.0, interval=1000.0, time_left=2800.0, count=1),
+        Periodic(
+            interval_counter=800.0,
+            initial_counter=1000.0,
+            interval=1000.0,
+            time_left=1800.0,
+            count=2,
+        ),
+        Periodic(
+            interval_counter=800.0,
+            initial_counter=1000.0,
+            interval=1000.0,
+            time_left=2800.0,
+            count=1,
+        ),
     ]
 
     start_current_field.elapse(4000)

--- a/tests/simulate/component/specific/mechanic/test_multiple_option.py
+++ b/tests/simulate/component/specific/mechanic/test_multiple_option.py
@@ -22,6 +22,7 @@ class TestMultipleOption:
             name="test-multiple-option",
             cooldown_duration=40_000,
             delay=690,
+            periodic_initial_delay=690,
             periodic_interval=1000,
             lasting_duration=120_000,
             missile_count=3,

--- a/tests/simulate/component/specific/windbreaker/test_howling_gale.py
+++ b/tests/simulate/component/specific/windbreaker/test_howling_gale.py
@@ -17,6 +17,7 @@ def fixture_howling_gale():
         maximum_stack=3,
         cooldown_duration=20_000,
         periodic_interval=150,
+        periodic_initial_delay=630,
         periodic_damage=[[500], [1000], [1000, 700]],
         periodic_hit=[[3], [3], [3, 3]],
         lasting_duration=9_850,

--- a/tests/simulate/test_save_load.py
+++ b/tests/simulate/test_save_load.py
@@ -24,6 +24,7 @@ def test_store_save_load():
         "y.interval",
         Periodic(
             interval_counter=3.0,
+            initial_counter=None,
             interval=8.5,
             time_left=2.0,
             count=13,


### PR DESCRIPTION
- 주기 공격을 하는 컴포넌트가 공격 개시 시점인 periodic_initial_delay를 가질 수 있도록 합니다.
- Periodic entity가 initial_delay를 가질 수 있습니다. None일 경우, 최초 딜레이는 interval로 설정됩니다.